### PR TITLE
Status check to see if feedstock build is broken

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: 6b6f4c6f93178a1295860a9dc6dc45e60fec70f684d5c8d0b59baf5b8dd44d62
 
 build:
-  number: 3
+  number: 4
   rpaths:
     - lib/R/lib/
     - lib/


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

---

The builds were able to find the conda-installed cairo last October for the R 4.4 migration (https://github.com/conda-forge/r-cairo-feedstock/pull/39). However, since then, the builds have been failing because they can't even find the conda-installed cairo (#42, #43). This PR is simply a status check. Is the failure to find cairo due to rerendering or some other external change (eg maybe to the cairo binary)?